### PR TITLE
always start rrd grephs at 0

### DIFF
--- a/data/PVE/Cluster.pm
+++ b/data/PVE/Cluster.pm
@@ -699,6 +699,7 @@ sub create_rrd_graph {
 	"--width" => 800,
 	"--start" => - $reso*$count,
 	"--end" => 'now' ,
+	"--lower-limit" => 0,
 	);
 
     my $socket = "/var/run/rrdcached.sock";


### PR DESCRIPTION
The rrd graphs look very strange if they do not always start at 0.
